### PR TITLE
add alias plugin for absolute path css access

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -79,6 +79,9 @@ module.exports = {
       copyright: `Copyright © ${new Date().getFullYear()} My Project, Inc. Built with Docusaurus.`,
     },
   },
+  plugins: [
+    require.resolve('./plugins/alias/src'), 
+  ],
   presets: [
     [
       require.resolve('./temp-preset'),

--- a/plugins/alias/src/index.js
+++ b/plugins/alias/src/index.js
@@ -1,0 +1,17 @@
+const path = require('path');
+
+module.exports = function(context, options) {
+  return {
+    name: 'alias-plugin',
+    configureWebpack(config, isServer, utils) {
+      const {getCacheLoader} = utils;
+      return {
+        resolve: {
+          alias: {
+            CSS: path.resolve(__dirname, '../../../src/css'),
+          }
+        }
+      };
+    },
+  };
+};

--- a/src/css/variables.module.css
+++ b/src/css/variables.module.css
@@ -1,0 +1,21 @@
+/* Breakpoints */
+@value small-mobile-breakpoint-size: 320;
+@value small-mobile-breakpoint-query: (min-width: calc(small-mobile-breakpoint-size * 1px));
+
+@value mobile-breakpoint-size: 420;
+@value mobile-breakpoint-query: (min-width: calc(mobile-breakpoint-size * 1px));
+
+@value small-tablet-breakpoint-size: 580;
+@value small-tablet-breakpoint-query: (min-width: calc(small-tablet-breakpoint-size * 1px));
+
+@value medium-tablet-breakpoint-size: 768;
+@value medium-tablet-breakpoint-query: (min-width: calc(medium-tablet-breakpoint-size * 1px));
+
+@value large-tablet-breakpoint-size: 1024;
+@value large-tablet-breakpoint-query: (min-width: calc(large-tablet-breakpoint-size * 1px));
+
+@value desktop-breakpoint-size: 1280;
+@value desktop-breakpoint-query: (min-width: calc(desktop-breakpoint-size * 1px));
+
+@value large-desktop-breakpoint-size: 1400;
+@value large-desktop-breakpoint-query: (min-width: calc(large-desktop-breakpoint-size * 1px));


### PR DESCRIPTION
This is the same thing that was happening on Lips. It is most useful for allowing the libra-docusaurus-nav module to access the css breakpoints, but will also make general access easier