### PR TITLE
feat(lib-664): swizzle DocPage

### DIFF
--- a/src/theme/DocPage/index.js
+++ b/src/theme/DocPage/index.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import {MDXProvider} from '@mdx-js/react';
+
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import renderRoutes from '@docusaurus/renderRoutes';
+import Layout from '@theme/Layout';
+import DocSidebar from '@theme/DocSidebar';
+import MDXComponents from '@theme/MDXComponents';
+import NotFound from '@theme/NotFound';
+import {matchPath} from '@docusaurus/router';
+
+import styles from './styles.module.css';
+
+function DocPage(props) {
+  const {route: baseRoute, docsMetadata, location} = props;
+  // case-sensitive route such as it is defined in the sidebar
+  const currentRoute =
+    baseRoute.routes.find((route) => {
+      return matchPath(location.pathname, route);
+    }) || {};
+  const {permalinkToSidebar, docsSidebars, version} = docsMetadata;
+  const sidebar = permalinkToSidebar[currentRoute.path];
+  const {
+    siteConfig: {themeConfig = {}} = {},
+    isClient,
+  } = useDocusaurusContext();
+  const {sidebarCollapsible = true} = themeConfig;
+
+  if (Object.keys(currentRoute).length === 0) {
+    return <NotFound {...props} />;
+  }
+
+  return (
+    <Layout version={version} key={isClient}>
+      <div className={styles.docPage}>
+        {sidebar && (
+          <div className={styles.docSidebarContainer}>
+            <DocSidebar
+              docsSidebars={docsSidebars}
+              path={currentRoute.path}
+              sidebar={sidebar}
+              sidebarCollapsible={sidebarCollapsible}
+            />
+          </div>
+        )}
+        <main className={styles.docMainContainer}>
+          <MDXProvider components={MDXComponents}>
+            {renderRoutes(baseRoute.routes)}
+          </MDXProvider>
+        </main>
+      </div>
+    </Layout>
+  );
+}
+
+export default DocPage;

--- a/src/theme/DocPage/styles.module.css
+++ b/src/theme/DocPage/styles.module.css
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.docPage {
+  display: flex;
+}
+
+.docSidebarContainer {
+  border-right: 1px solid var(--ifm-contents-border-color);
+  box-sizing: border-box;
+  width: 300px;
+  position: relative;
+  margin-top: calc(-1 * var(--ifm-navbar-height));
+}
+
+.docMainContainer {
+  flex-grow: 1;
+}
+
+@media (max-width: 996px) {
+  .docPage {
+    display: inherit;
+  }
+
+  .docSidebarContainer {
+    margin-top: 0;
+  }
+}


### PR DESCRIPTION
This is necessary in the long term because with our nav-spacer fix (for a fixed navbar), we need to hook into this components lifecycle and onMount go to the top of the page. Otherwise going to a new page won't take you to the top

In the short term it will allow us to pass in our own doc components to be natively parsed by mdx, which means we don't need to import them in the doc pages and can simply just use them! 