### PR TITLE
feat(lib-664): add our own doc components to mdx shortocdes

### DIFF
--- a/src/components/docs/index.js
+++ b/src/components/docs/index.js
@@ -1,0 +1,1 @@
+export default {};

--- a/src/theme/DocPage/index.js
+++ b/src/theme/DocPage/index.js
@@ -12,11 +12,15 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import renderRoutes from '@docusaurus/renderRoutes';
 import Layout from '@theme/Layout';
 import DocSidebar from '@theme/DocSidebar';
-import MDXComponents from '@theme/MDXComponents';
+import ThemeComponents from '@theme/MDXComponents';
 import NotFound from '@theme/NotFound';
 import {matchPath} from '@docusaurus/router';
 
+import DocComponents from 'Components/docs';
+
 import styles from './styles.module.css';
+
+const MDXComponents = Object.assign(ThemeComponents, DocComponents);
 
 function DocPage(props) {
   const {route: baseRoute, docsMetadata, location} = props;


### PR DESCRIPTION
When we add doc components, we won't need to import them to use them in our doc pages